### PR TITLE
feat(recipe-book): add automated recipe scraping via URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ HomeHub is packed with useful tools to make family life a little more organized:
 * **👋 Who's Home?**: See at a glance who is currently home.
 * **💰 Expense Tracker**: A powerful tool to track family spending, with support for recurring bills like newspapers, milk, or subscriptions.
 * **🎬 Media Downloader**: Save videos or music from popular sites directly to your server.
-* ...and more, including a **Recipe Book**, **Expiry Tracker**, **URL Shortener**, **PDF Compressor**, and **QR Code Generator**!
+* ...and more, including a **Recipe Book** (Automatically import recipes from over 50+ websites using [recipe-scrapers](https://github.com/hhursev/recipe-scrapers)), **Expiry Tracker**, **URL Shortener**, **PDF Compressor**, and **QR Code Generator**!
 
 ## Salient Features
 * **Private & Self-Hosted**: All your data stays on your network. No cloud, no tracking.

--- a/app/blueprints/recipes.py
+++ b/app/blueprints/recipes.py
@@ -89,9 +89,9 @@ def scrape_recipe():
 
     try:
         scraper = scrape_me(link)
-        scraped_title = scraper.title()
-        scraped_ingredients = '\n'.join(scraper.ingredients())
-        scraped_instructions = scraper.instructions()
+        scraped_title = sanitize_text(scraper.title())
+        scraped_ingredients = sanitize_html('\n'.join(scraper.ingredients()))
+        scraped_instructions = sanitize_html(scraper.instructions())
         
         flash(f'Successfully scraped: {scraped_title}', 'success')
         

--- a/app/blueprints/recipes.py
+++ b/app/blueprints/recipes.py
@@ -95,7 +95,7 @@ def scrape_recipe():
         
         flash(f'Successfully scraped: {scraped_title}', 'success')
         
-        return render_template('recipes.html', recipes=recipes, config=config, form_title=scraped_title, form_link=link,form_ingredients=scraped_ingredients,                              form_instructions=scraped_instructions)
+        return render_template('recipes.html', recipes=recipes, config=config, form_title=scraped_title, form_link=link,form_ingredients=scraped_ingredients, form_instructions=scraped_instructions)
 
     except Exception as e:
         flash(f'Scraping failed: {str(e)}', 'error')

--- a/app/blueprints/recipes.py
+++ b/app/blueprints/recipes.py
@@ -95,7 +95,7 @@ def scrape_recipe():
         
         flash(f'Successfully scraped: {scraped_title}', 'success')
         
-        return render_template('recipes.html', recipes=recipes, config=config, form_title=scraped_title, form_link=link,form_ingredients=scraped_ingredients, form_instructions=scraped_instructions)
+        return render_template('recipes.html', recipes=recipes, config=config, form_title=scraped_title, form_link=link, form_ingredients=scraped_ingredients, form_instructions=scraped_instructions)
 
     except Exception as e:
         flash(f'Scraping failed: {str(e)}', 'error')

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ gunicorn
 Flask-WTF
 bleach
 pytest
+recipe-scrapers

--- a/templates/recipes.html
+++ b/templates/recipes.html
@@ -7,7 +7,7 @@
         <input type="text" name="title" value="{{ form_title if form_title is defined else '' }}" class="w-full p-2 border rounded mb-2" placeholder="Recipe title..." required>
         <div class="flex gap-2 mb-2">
             <input type="url" name="link" id="link-input" value="{{ form_link if form_link is defined else '' }}" class="flex-1 p-2 border rounded" placeholder="Link (optional)">
-            <button type="submit" formaction="/recipes/scrape" formnovalidate id="scrape-btn" class="btn btn-secondary px-4" title="Enter a URL and click here to auto-fill the recipe details"><i class="fa-solid fa-wand-magic-sparkles"></i></button>
+            <button type="submit" formaction="/recipes/scrape" formnovalidate id="scrape-btn" class="btn btn-secondary px-4" title="Enter a URL and click here to auto-fill the recipe details" aria-label="Scrape recipe from URL"><i class="fa-solid fa-wand-magic-sparkles"></i></button>
         </div>
         <textarea name="ingredients" class="w-full p-2 border rounded mb-2" placeholder="Ingredients...">{{ form_ingredients if form_ingredients is defined else '' }}</textarea>
         <textarea name="instructions" class="w-full p-2 border rounded mb-2" placeholder="Instructions...">{{ form_instructions if form_instructions is defined else '' }}</textarea>

--- a/templates/recipes.html
+++ b/templates/recipes.html
@@ -5,7 +5,10 @@
     <form method="POST" action="/recipes" class="mb-4 card p-4">
         <input type="hidden" name="recipe_id" value="{{ form_recipe_id if form_recipe_id is defined else '' }}">
         <input type="text" name="title" value="{{ form_title if form_title is defined else '' }}" class="w-full p-2 border rounded mb-2" placeholder="Recipe title..." required>
-        <input type="url" name="link" value="{{ form_link if form_link is defined else '' }}" class="w-full p-2 border rounded mb-2" placeholder="Link (optional)">
+        <div class="flex gap-2 mb-2">
+            <input type="url" name="link" id="link-input" value="{{ form_link if form_link is defined else '' }}" class="flex-1 p-2 border rounded" placeholder="Link (optional)">
+            <button type="submit" formaction="/recipes/scrape" formnovalidate id="scrape-btn" class="btn btn-secondary px-4" title="Enter a URL and click here to auto-fill the recipe details"><i class="fa-solid fa-wand-magic-sparkles"></i></button>
+        </div>
         <textarea name="ingredients" class="w-full p-2 border rounded mb-2" placeholder="Ingredients...">{{ form_ingredients if form_ingredients is defined else '' }}</textarea>
         <textarea name="instructions" class="w-full p-2 border rounded mb-2" placeholder="Instructions...">{{ form_instructions if form_instructions is defined else '' }}</textarea>
     <input type="hidden" name="creator" id="creator">
@@ -43,6 +46,11 @@ document.querySelectorAll('input[name="user"]').forEach(i=> i.value = localStora
 (function(){
     const form = document.querySelector('form[method="POST"]');
     form.addEventListener('submit', function(e){
+        const btn = e.submitter;
+        const btnAction = btn ? btn.getAttribute('formaction') : null;
+        if (btnAction && btnAction.includes('scrape')) {
+            return; // Skip validation for scrape requests
+        }
         const ing = (form.querySelector('textarea[name="ingredients"]').value||'').trim();
         const ins = (form.querySelector('textarea[name="instructions"]').value||'').trim();
         if(!ing && !ins){


### PR DESCRIPTION
## Description
This PR adds a new "Scrape" feature to the recipe creation, allowing users to automatically populate recipe details (title, ingredients, instructions) by pasting a URL from a supported recipe website.

## Changes
- **Backend**: Added a new `/recipes/scrape` endpoint in `recipes.py` using the `recipe-scrapers` library.
- **Frontend**:
  - Added a "Scrape" button with a tooltip to the recipe form.
  - Implemented a flexbox layout for the URL input and button.
  - Updated client-side validation to bypass required fields during scrape requests.
- **Dependencies**: Added `recipe-scrapers` to the project.

## How to Test
1. Navigate to the "Recipe Book" page.
2. Paste a valid recipe URL (e.g., from AllRecipes or FoodNetwork) into the "Link" field.
3. Click the **Scrape** button.
4. Verify that the Title, Ingredients, and Instructions fields are automatically filled.
5. Click "Save" and ensure the recipe is created successfully.

## Screenshots
<img width="636" height="395" alt="grafik" src="https://github.com/user-attachments/assets/470bf941-71c1-4f77-b934-50904cad786e" />

## Checklist
- [x] New dependency `recipe-scrapers` added.
- [x] Tooltip added to explain functionality.
- [x] Form validation updated to handle non-save actions.
